### PR TITLE
Fix Konnekt function type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,9 @@ function Konnekt<OwnProps, Props>(
   hooksToProps: HooksToPropsFunction<OwnProps, Props>,
   options: KonnektOptions = defaultOptions
 ) {
-  return function(Component: React.ComponentType<OwnProps & Props>) {
+  return function(
+    Component: React.ComponentType<OwnProps & Props>
+  ): React.ComponentType<OwnProps> {
     const Konnekted = function(props: OwnProps) {
       const hooksProps = hooksToProps(props);
       return <Component {...props} {...hooksProps} />;


### PR DESCRIPTION
This fixes a bug in TypeScript by setting the right component props type of the new Konnekted component.

For example:

```jsx
interface ButtonProps {
    onClick: () => void;
    label: string;
}

function Button({ onClick, label } : ButtonProps) {
    return (
        <button onClick={onClick}>{label}</button>
    );
}

const CountButton = Konnekt<{ prefix: string }, ButtonProps>((ownProps) => {
    const [counter, setCounter] = useState(0);
    return {
        onClick: () => setCounter(counter+1),
        label: `${ownProps.prefix}: ${counter}`,
    };
})(Button);
```

Rendering the `CountButton` without `prefix`:
```jsx
<CountButton />
```
won't raise a TypeScript error.

This patch fixes this by defining the type of the returned value from the wrapped function.